### PR TITLE
Add an ast parser that uses jedi for primitive type inference

### DIFF
--- a/ePYt/epytlib/ast_parser.py
+++ b/ePYt/epytlib/ast_parser.py
@@ -1,0 +1,37 @@
+import ast
+from jedi import Script
+
+
+class _Instrumenter (ast.NodeTransformer):
+    def __init__(self, script: Script):
+        self.script = script
+
+    def visit_Assign(self, node: ast.Assign):
+        node.type = None
+        line, column = node.lineno, node.col_offset
+        inferred_type = self.script.infer(line, column)
+        if inferred_type:
+            node.type = inferred_type[0]
+        return node
+
+
+
+''' 
+    Parse a python file and returns ast with inferred type information for Assign nodes.
+    The inferred type can be accessed using node.type for Assign's.
+    Todo: Change inferred type format to our own type kind
+'''
+def parse_with_type_info (filename):
+    script = Script(path=filename)
+    instrumenter = _Instrumenter(script)
+    lines = open(filename, "r").readlines()
+    root = ast.parse ("".join(lines), filename)
+    return instrumenter.visit(root)
+
+
+# root = parse_with_type_info("../../../example1.py")
+# print("Root =", ast.dump(root, True, indent = 4))
+
+
+
+


### PR DESCRIPTION
This phase should precede creating the graph. We can just use the ast root generated by calling the parse function. We need to make the inferred type match our own type kinds that we need to implement. 